### PR TITLE
Add Radarr Support

### DIFF
--- a/NewFeatures_README.md
+++ b/NewFeatures_README.md
@@ -2,6 +2,16 @@
 
 This document outlines the additional features added to the Plex Dupefinder Python application.
 
+- [Dry Run Option](#dry-run-option)
+- [Prevent Plex Optimized Versions](#preventing-plex-optimized-versions)
+- [Handle Unavailable Files](#handling-unavailable-media-files)
+- [Delete .TS Files](#deleting-extra-ts-files)
+- [Skip Other Dupes (only delete Unavailable and .TS)](#skipping-other-duplicate-checks-batch-mode)
+- [Docker Image Support](#docker-image-support)
+- [Additional Scoring Options](#additional-scoring-options)
+- [Activity Log Date & Timezone](#activity-log-date--timezone)
+- [Radarr Support](#radarr-support)
+
 ## Dry Run Option
 
 The dry run option allows users to simulate the deletion process without actually deleting any files. This option is configured using the `DRY_RUN` parameter in the `config.json` file. When enabled, Plex Dupefinder will log potential delete operations without carrying them out.
@@ -45,3 +55,11 @@ Three additional options (`SCORE_VIDEOBITRATE`, `SCORE_AUDIOCHANNELS`, and `VIDE
 ## Activity Log Date & Timezone
 
 The `activity.log` file now tracks the date of every line as well as the timezone defined in the `config.json` file. The default value is UTC which mirrors the original script's functionality, if you would like to see the logs reported in a different timezone (such as the one your server is hosted in), update the `LOGGING_TIMEZONE` config value to match the **TZ_Identifier** from the table in [this wikipedia page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This will properly align with any shifts for daylight savings time.
+
+## Radarr Support
+
+Added support to use Radarr as the file selector. This is most useful if you have custom scoring formats (such as those from [TRaSH Guides](https://trash-guides.info/)) for your Radarr installation already defined, allowing you to use those configurations rather than having to recreate the same or different settings in this tool.
+
+When the `RADARR` setting has the **enabled** option set to `true`, Plex Dupefinder will use the configured **url** and **api_key** to query Radarr for which file it has imported for a given movie.
+
+If `AUTO_DELETE` is enabled, the file Radarr has on record will be the default selection. If the connection to Radarr fails or there is otherwise an issue it will fallback to the standard scoring method. If `AUTO_DELETE` is disabled, the file Radarr has on record will be marked with a ⭐ and using the "r" option will auto-select the Radarr determined file.

--- a/config.py
+++ b/config.py
@@ -38,7 +38,7 @@ base_config = {
             'multiplier': 2
         },
         'RADARR': {  # Optionally, use Radarr to determine which file to keep
-            'enabled': false,
+            'enabled': False,
             'url': "http://localhost:7878",
             'api_key': "abc123"
         }

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ base_config = {
     'PLEX': {  # Overarching category for Plex server settings
         'LIBRARIES': {},  # Plex libraries to scan (e.g., ['Movies', 'TV'])
         'SERVER_URL': 'https://plex.your-server.com',  # Plex server URL (https/http)
-        'AUTH_TOKEN': '',  # Plex API token (fetched via login or manually set)
+        'AUTH_TOKEN': ''  # Plex API token (fetched via login or manually set)
     },
     'SCORING': {  # Overarching category for enabling/disabling various scoring options
         'VIDEO_HEIGHT_MULTIPLIER': 2,  # Used in scoring: height (in pixels) * multiplier
@@ -37,6 +37,11 @@ base_config = {
             'enabled': True,
             'multiplier': 2
         },
+        'RADARR': {  # Optionally, use Radarr to determine which file to keep
+            'enabled': false,
+            'url': "http://localhost:7878",
+            'api_key': "abc123"
+        }
     },
     'AUDIO_CODEC_SCORES': {  # Custom audio codec scoring
         'Unknown': 0, 'wmapro': 200, 'mp2': 500, 'mp3': 1000, 'ac3': 1000, 'dca': 2000, 'pcm': 2500, 

--- a/config_sample.json
+++ b/config_sample.json
@@ -24,6 +24,11 @@
     "SCORE_VIDEOBITRATE": {
       "enabled": true,
       "multiplier": 2
+    },
+    "RADARR": {
+      "enabled": false,
+      "url": "http://localhost:7878",
+      "api_key": "abc123"
     }
   },
   "AUDIO_CODEC_SCORES": {

--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -202,7 +202,7 @@ def get_item_metadata(item, item_metadata=None):
 
     return metadata
 
-def get_media_info(item):
+def get_media_info(item, item_metadata):
     """
     Extract relevant metadata from a Plex media item object.
     This includes codecs, resolution, bitrate, dimensions,
@@ -542,10 +542,10 @@ def get_arr_override_id(parts):
     Only used if *arr integration is enabled in config.
     """
     # Radarr logic for movies
-    if ['SCORING']['RADARR']['enabled']:
+    if cfg['SCORING']['RADARR']['enabled']:
         for media_id, part_info in parts.items():
-            if part_info.get('media_type') == 'movie':
-                tmdb_id = part_info.get('tmdb_id')
+            if part_info['media_type'] == 'movie':
+                tmdb_id = part_info['tmdb_id']
                 if tmdb_id:
                     radarr_file = get_radarr_file(tmdb_id)
                     if radarr_file and os.path.basename(part_info['file'][0]) == radarr_file:


### PR DESCRIPTION
Add support for Radarr based file selection. Updates include:

- Nested duplicate processing within a try/except that catches keyboard interrupts to maintain summary output.
- Update the NewFeatures_README.md to account for radarr support.
- Update config.py and config sample for Radarr settings.
- Update plex_dupefinder.py for additional *arr logic (radarr only, but some groundwork for sonarr).