### PR TITLE
Add Sonarr Support

### DIFF
--- a/NewFeatures_README.md
+++ b/NewFeatures_README.md
@@ -10,7 +10,7 @@ This document outlines the additional features added to the Plex Dupefinder Pyth
 - [Docker Image Support](#docker-image-support)
 - [Additional Scoring Options](#additional-scoring-options)
 - [Activity Log Date & Timezone](#activity-log-date--timezone)
-- [Radarr Support](#radarr-support)
+- [Radarr & Sonarr Support](#radarr--sonarr-support)
 
 ## Dry Run Option
 
@@ -56,10 +56,10 @@ Three additional options (`SCORE_VIDEOBITRATE`, `SCORE_AUDIOCHANNELS`, and `VIDE
 
 The `activity.log` file now tracks the date of every line as well as the timezone defined in the `config.json` file. The default value is UTC which mirrors the original script's functionality, if you would like to see the logs reported in a different timezone (such as the one your server is hosted in), update the `LOGGING_TIMEZONE` config value to match the **TZ_Identifier** from the table in [this wikipedia page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This will properly align with any shifts for daylight savings time.
 
-## Radarr Support
+## Radarr & Sonarr Support
 
-Added support to use Radarr as the file selector. This is most useful if you have custom scoring formats (such as those from [TRaSH Guides](https://trash-guides.info/)) for your Radarr installation already defined, allowing you to use those configurations rather than having to recreate the same or different settings in this tool.
+Added support to use Radarr and/or Sonarr as the file selector. This is most useful if you have custom scoring formats (such as those from [TRaSH Guides](https://trash-guides.info/)) for your Radarr or Sonarr installation already defined, allowing you to use those configurations rather than having to recreate the same or different settings in this tool.
 
-When the `RADARR` setting has the **enabled** option set to `true`, Plex Dupefinder will use the configured **url** and **api_key** to query Radarr for which file it has imported for a given movie.
+When the `RADARR` or `SONARR` setting has the **enabled** option set to `true`, Plex Dupefinder will use the configured **url** and **api_key** to query Radarr or Sonarr for which file it has imported for a given movie or episode.
 
-If `AUTO_DELETE` is enabled, the file Radarr has on record will be the default selection. If the connection to Radarr fails or there is otherwise an issue it will fallback to the standard scoring method. If `AUTO_DELETE` is disabled, the file Radarr has on record will be marked with a ⭐ and using the "r" option will auto-select the Radarr determined file.
+If `AUTO_DELETE` is enabled, the file Radarr/Sonarr has on record will be the default selection to keep. If the connection to Radarr/Sonarr fails or there is otherwise an issue it will fallback to the standard scoring method. If `AUTO_DELETE` is disabled, the file Radarr/Sonarr has on record will be marked with a ⭐ and using the "r" option will auto-select the Radarr/Sonarr determined file.

--- a/config.py
+++ b/config.py
@@ -41,6 +41,11 @@ base_config = {
             'enabled': False,
             'url': "http://localhost:7878",
             'api_key': "abc123"
+        },
+        'SONARR': {  # Optionally, use Sonarr to determine which file to keep
+            'enabled': False,
+            'url': "http://localhost:8989",
+            'api_key': "abc123"
         }
     },
     'AUDIO_CODEC_SCORES': {  # Custom audio codec scoring

--- a/config_sample.json
+++ b/config_sample.json
@@ -29,6 +29,11 @@
       "enabled": false,
       "url": "http://localhost:7878",
       "api_key": "abc123"
+    },
+    "SONARR": {
+      "enabled": true,
+      "url": "http://localhost:8989",
+      "api_key": "abc123"
     }
   },
   "AUDIO_CODEC_SCORES": {


### PR DESCRIPTION
Implement ability to use Sonarr for TV Show file determination. This is optimal when using custom Sonarr scoring (such as that available from [TRaSH Guides](https://trash-guides.info/Sonarr/) ) so it has "best match" already imported and disregards any "dupefinder" scoring.